### PR TITLE
ABI creation helpers as xelis_abi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,12 +249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +336,12 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "half"
@@ -529,11 +529,13 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,31 +52,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
-
-[[package]]
 name = "better_any"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1795ebc740ea791ffbe6685e0688ab1effec16c2864e0476db40bfdf0c02cb3d"
-
-[[package]]
-name = "bitflags"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
@@ -338,12 +302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,12 +329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
-
-[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,17 +337,6 @@ dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -468,41 +409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -631,12 +543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,20 +643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
-dependencies = [
- "backtrace",
- "io-uring",
- "libc",
- "mio",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,12 +657,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -796,19 +682,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -848,16 +721,6 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -950,16 +813,8 @@ name = "xelis-abi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "humantime",
- "indexmap",
- "serde",
- "serde_json",
- "tokio",
- "wasm-bindgen-futures",
- "web-time",
  "xelis-ast",
  "xelis-builder",
- "xelis-bytecode",
  "xelis-compiler",
  "xelis-lexer",
  "xelis-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,15 +40,15 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "assembler"
@@ -47,9 +62,24 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "better_any"
@@ -58,10 +88,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1795ebc740ea791ffbe6685e0688ab1effec16c2864e0476db40bfdf0c02cb3d"
 
 [[package]]
-name = "bumpalo"
-version = "3.16.0"
+name = "bitflags"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cast"
@@ -71,9 +107,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "ciborium"
@@ -104,18 +140,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -123,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "criterion"
@@ -190,33 +226,39 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -224,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -235,15 +277,21 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -251,14 +299,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.13"
+name = "io-uring"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -281,15 +340,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -303,21 +362,41 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "num-traits"
@@ -329,22 +408,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.2"
+name = "object"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "plotters"
@@ -376,18 +470,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -442,10 +536,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustc-demangle"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -458,18 +564,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -478,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -489,10 +595,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.90"
+name = "slab"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -501,18 +613,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.8"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.8"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -530,10 +642,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.14"
+name = "tokio"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+dependencies = [
+ "backtrace",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "walkdir"
@@ -546,21 +672,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -571,10 +704,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.99"
+name = "wasm-bindgen-futures"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -582,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -595,15 +741,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -615,16 +774,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
+ "windows-sys",
 ]
 
 [[package]]
@@ -699,6 +849,28 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "xelis-abi"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "humantime",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "tokio",
+ "wasm-bindgen-futures",
+ "web-time",
+ "xelis-ast",
+ "xelis-builder",
+ "xelis-bytecode",
+ "xelis-compiler",
+ "xelis-lexer",
+ "xelis-parser",
+ "xelis-types",
+ "xelis-vm",
+]
 
 [[package]]
 name = "xelis-ast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 
 members = [
+    "abi",
     "types",
     "bytecode",
     "vm",

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "xelis-abi"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+xelis-types = { path = "../types" }
+xelis-vm = { path = "../vm" }
+xelis-ast = { path = "../ast" }
+xelis-bytecode = { path = "../bytecode" }
+xelis-compiler = { path = "../compiler" }
+xelis-parser = { path = "../parser" }
+xelis-lexer = { path = "../lexer" }
+xelis-builder = { path = "../builder" }
+
+anyhow = "1.0.93"
+web-time = "1.1.0"
+humantime = "2.1.0"
+tokio = { version = "1.42.0", features = ["rt"] }
+wasm-bindgen-futures = "0.4.45"
+indexmap = "2.10.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# [dev-dependencies]
+# xelis-serializer = {}
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -7,19 +7,12 @@ edition = "2021"
 xelis-types = { path = "../types" }
 xelis-vm = { path = "../vm" }
 xelis-ast = { path = "../ast" }
-xelis-bytecode = { path = "../bytecode" }
 xelis-compiler = { path = "../compiler" }
 xelis-parser = { path = "../parser" }
 xelis-lexer = { path = "../lexer" }
 xelis-builder = { path = "../builder" }
 
 anyhow = "1.0.93"
-web-time = "1.1.0"
-humantime = "2.1.0"
-tokio = { version = "1.42.0", features = ["rt"] }
-wasm-bindgen-futures = "0.4.45"
-indexmap = "2.10.0"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [lib]

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -22,8 +22,5 @@ indexmap = "2.10.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-# [dev-dependencies]
-# xelis-serializer = {}
-
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/abi/silex/example.abi.json
+++ b/abi/silex/example.abi.json
@@ -1,0 +1,67 @@
+{
+  "data": [
+    {
+      "chunk_id": 2,
+      "name": "path_test",
+      "outputs": "u64",
+      "params": [],
+      "type": "entry"
+    },
+    {
+      "chunk_id": 4,
+      "name": "get_factorial",
+      "outputs": "u64",
+      "params": [
+        {
+          "name": "a",
+          "type": "u64"
+        }
+      ],
+      "type": "entry"
+    },
+    {
+      "chunk_id": 5,
+      "name": "address_test",
+      "outputs": "u64",
+      "params": [
+        {
+          "name": "addy",
+          "type": "Address"
+        },
+        {
+          "name": "amt",
+          "type": "u64"
+        }
+      ],
+      "type": "entry"
+    },
+    {
+      "chunk_id": 6,
+      "name": "person_param_test",
+      "outputs": "u64",
+      "params": [
+        {
+          "fields": [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "age",
+              "type": "u8"
+            },
+            {
+              "name": "employed",
+              "type": "bool"
+            }
+          ],
+          "internalType": "Person",
+          "name": "person",
+          "type": "struct"
+        }
+      ],
+      "type": "entry"
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/abi/silex/example.slx
+++ b/abi/silex/example.slx
@@ -2,6 +2,12 @@ struct Value {
 	value: string
 }
 
+struct Person {
+  name: string,
+  age: u8,
+  employed: bool
+}
+
 fn (v Value) my_value() -> string {
 	return v.value
 }
@@ -37,5 +43,10 @@ entry get_factorial(a: u64) {
 
 entry address_test(addy: Address, amt: u64) {
   println(addy)
+  return 0
+}
+
+entry person_param_test(person: Person) {
+  println(person)
   return 0
 }

--- a/abi/silex/example.slx
+++ b/abi/silex/example.slx
@@ -1,0 +1,41 @@
+struct Value {
+	value: string
+}
+
+fn (v Value) my_value() -> string {
+	return v.value
+}
+
+struct Message {
+	value: Value
+}
+
+fn (m Message) to_string() -> string {
+	return m.value.value
+}
+
+entry path_test() {
+	let message: Message = Message { value: Value { value: "Hello World!" } }
+	println(message.to_string())
+	message.value.value += " from path"
+	println(message.value.my_value())
+	return 0
+}
+
+fn factorial(n: u64) -> u64 {
+	if n == 0 {
+		return 1
+	}
+	return n * factorial(n - 1)
+}
+
+entry get_factorial(a: u64) {
+	println(factorial(a))
+
+	return 0
+}
+
+entry address_test(addy: Address, amt: u64) {
+  println(addy)
+  return 0
+}

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -1,0 +1,320 @@
+use xelis_builder::EnvironmentBuilder;
+use xelis_lexer::Lexer;
+use xelis_parser::Parser;
+use xelis_types::Type;
+use xelis_ast::*;
+
+use xelis_parser::mapper::GlobalMapper;
+use xelis_builder::Builder;
+
+pub fn abi_from_silex<M>(code: &str, env: EnvironmentBuilder<'_, M>) -> anyhow::Result<String> {
+    let tokens = Lexer::new(code)
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let parser = Parser::with(tokens.into_iter(), &env);
+    let (program, mapper) = parser.parse().map_err(|err| anyhow::anyhow!("{:#}", err))?;
+
+    abi_from_parse(program, &mapper, &env)
+}
+
+pub fn abi_from_parse<M>(program: Program, mapper: &GlobalMapper, environment: &EnvironmentBuilder<M>) -> anyhow::Result<String> {
+    // Collect all the available entry functions
+    let mut abi_functions: Vec<serde_json::Value> = Vec::new();
+    for (i, func) in program.functions().iter().enumerate() {
+        let env_offset = environment.get_functions().len() as u16;
+
+        if func.is_entry() {
+            let function_builder = mapper.functions();
+            let mapping = function_builder
+                .get_function(&(i as u16 + env_offset))
+                .unwrap();
+
+            let mut flattened_params = Vec::new();
+
+            for (name, _type) in &mapping.parameters {
+                match _type {
+                    Type::Struct(struct_type) => {
+                        let struct_fields: Vec<(String, Type)> = struct_type
+                            .fields()
+                            .iter()
+                            .enumerate()
+                            .map(|(i, (_name, ty))| (format!("field{}", i), ty.clone()))
+                            .collect();
+
+                        let builder = mapper
+                            .structs();
+
+                        let struct_field_names: Vec<&str> = builder
+                            .get_by_ref(&struct_type)?
+                            .names()
+                            .collect();
+
+                        let name_info = builder.get_name_by_ref(&struct_type)?;
+
+                        let mut struct_data = Vec::new();
+                        for (field_index, field_type) in struct_fields.iter().enumerate() {
+                            struct_data.push(serde_json::json!({
+                                "name": struct_field_names[field_index],
+                                "type": field_type.1.to_string(),
+                            }));
+                        }
+
+                        flattened_params.push(
+                            serde_json::json!({
+                                "name": name,
+                                "type": "struct",
+                                "internalType": name_info,
+                                "fields": struct_data
+                            })
+                        )
+                    },
+                    Type::Enum(enum_type) => {
+
+                        let builder = mapper
+                            .enums();
+
+                        let name_info = builder.get_name_by_ref(&enum_type)?;
+
+                        flattened_params.push(serde_json::json!({
+                            "name": name.to_string(),
+                            "type": format!("enum"),
+                            "internalType": name_info
+                        }));
+                    },
+                    _ => {
+                        flattened_params.push(serde_json::json!({
+                            "name": name.to_string(),
+                            "type": _type.to_string(),
+                        }));
+                    }
+                }
+            }
+
+            let abi_entry = serde_json::json!({
+                "name": mapping.name.to_owned(),
+                "type": "entry",
+                "chunk_id": i as u16,
+                "params": flattened_params,
+                "outputs": func.return_type().clone().map(|rt| rt.to_string()).unwrap_or_else(|| "void".to_string()),
+            });
+            abi_functions.push(abi_entry);
+        }
+    }
+
+    Ok(serde_json::to_string_pretty(&abi_functions)?)
+}
+
+// TODO: re-add import support and switch to something like below
+// Below is the original version from v1 of ABI/Imports. 
+
+// pub fn abi_from_parse(program: Program, mapper: &GlobalMapper, environment: &EnvironmentBuilder) -> anyhow::Result<String> {
+//     // Collect all the available entry functions
+//     let mut abi_functions: Vec<serde_json::Value> = Vec::new();
+//     for (i, func) in program.functions().iter().enumerate() {
+//         let env_offset = environment.get_functions().len() as u16;
+
+//         if func.is_entry() {
+//             let function_builder = mapper.functions();
+//             let mapping = function_builder
+//                 .get_function(&(i as u16 + env_offset))
+//                 .unwrap();
+
+//             let mut flattened_params = Vec::new();
+
+//             for (name, _type) in &mapping.parameters {
+//                 match _type {
+//                     Type::Struct(struct_type) => {
+//                         let struct_fields: Vec<(String, Type)> = struct_type.fields().iter().enumerate().map(|(i, field_type)| {
+//                             (format!("field{}", i), field_type.clone())
+//                         }).collect();
+
+//                         let builder = mapper
+//                             .structs();
+
+//                         let struct_field_names: Vec<&str> = builder
+//                             .get_by_ref(&struct_type)?
+//                             .names()
+//                             .clone();
+
+
+//                         let name_info = builder.get_name_by_ref(&struct_type)?;
+//                         let namespace = &name_info.1;
+//                         let prefix = if namespace.is_empty() {
+//                             "".to_string()
+//                         } else {
+//                             namespace.join("::") + "::"
+//                         };
+
+//                         let mut struct_data = Vec::new();
+//                         for (field_index, field_type) in struct_fields.iter().enumerate() {
+//                             struct_data.push(serde_json::json!({
+//                                 "name": struct_field_names[field_index],
+//                                 "type": field_type.1.to_string(),
+//                             }));
+//                         }
+
+//                         flattened_params.push(
+//                             serde_json::json!({
+//                                 "name": name,
+//                                 "type": "struct",
+//                                 "internalType": format!("{}{}", prefix, name_info.0),
+//                                 "fields": struct_data
+//                             })
+//                         )
+//                     },
+//                     Type::Enum(enum_type) => {
+
+//                         let builder = mapper
+//                             .enums();
+
+//                         let name_info = builder.get_name_by_ref(&enum_type)?;
+//                         let namespace = &name_info.1;
+//                         let prefix = if namespace.is_empty() {
+//                             "".to_string()
+//                         } else {
+//                             namespace.join("::") + "::"
+//                         };
+
+//                         flattened_params.push(serde_json::json!({
+//                             "name": name.to_string(),
+//                             "type": format!("enum"),
+//                             "internalType": format!("{}{}", prefix, name_info.0)
+//                         }));
+//                     },
+//                     _ => {
+//                         flattened_params.push(serde_json::json!({
+//                             "name": name.to_string(),
+//                             "type": _type.to_string(),
+//                         }));
+//                     }
+//                 }
+//             }
+
+//             let namespace = &mapping.namespace;
+//             let is_root = namespace.is_empty() || (
+//                 namespace.len() == 1 && namespace[0] == ""
+//             );
+
+//             let prefix = if is_root {
+//                 "".to_string()
+//             } else {
+//                 namespace.join("::") + "::"
+//             };
+
+//             let abi_entry = serde_json::json!({
+//                 "name": format!("{}{}", prefix, mapping.name.to_owned()),
+//                 "type": "entry",
+//                 "chunk_id": i as u16,
+//                 "params": flattened_params,
+//                 "outputs": func.return_type().clone().map(|rt| rt.to_string()).unwrap_or_else(|| "void".to_string()),
+//             });
+//             abi_functions.push(abi_entry);
+//         }
+//     }
+
+//     Ok(serde_json::to_string_pretty(&abi_functions)?)
+// }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::marker::PhantomData;
+
+    use xelis_builder::{EnvironmentBuilder};
+    use xelis_types::{Type, Opaque, OpaqueType, traits::{
+      DynType, DynEq, DynHash, JSONHelper, Serializable
+    }};
+
+    macro_rules! impl_dummy_opaque {
+        ($name:ident) => {
+            #[derive(Debug)]
+            pub struct $name;
+
+            impl DynType for $name {
+                fn get_type_name(&self) -> &'static str {
+                    stringify!($name)
+                }
+                fn get_type(&self) -> std::any::TypeId {
+                    std::any::TypeId::of::<Self>()
+                }
+            }
+
+            impl DynEq for $name {
+                fn as_eq(&self) -> &(dyn DynEq + 'static) {
+                    self
+                }
+                fn is_equal(&self, _other: &(dyn DynEq + 'static)) -> bool {
+                    false
+                }
+            }
+
+            impl DynHash for $name {
+                fn dyn_hash(&self, _: &mut dyn std::hash::Hasher) {}
+            }
+
+            impl JSONHelper for $name {
+                fn serialize_json(&self) -> anyhow::Result<serde_json::Value> {
+                    Ok(serde_json::json!("dummy"))
+                }
+
+                fn is_json_supported(&self) -> bool {
+                    true
+                }
+            }
+
+            impl Serializable for $name {
+                fn get_size(&self) -> usize {
+                    8
+                }
+
+                fn serialize(&self, _: &mut Vec<u8>) -> usize {
+                    0
+                }
+
+                fn is_serializable(&self) -> bool {
+                    false
+                }
+            }
+
+            impl Opaque for $name {
+                fn clone_box(&self) -> Box<dyn Opaque> {
+                    Box::new($name)
+                }
+            }
+        };
+    }
+
+    // Dummy type definitions to register opaque types
+    impl_dummy_opaque!(Address);
+
+    pub struct TestStorage {
+        _phantom: PhantomData<()>,
+    }
+
+    impl Default for TestStorage {
+        fn default() -> Self {
+            Self { _phantom: PhantomData }
+        }
+    }
+
+    #[test]
+    fn test_abi_from_example_slx() {
+        let code = fs::read_to_string("./silex/example.slx")
+            .expect("Failed to read example.slx");
+
+        let mut env: EnvironmentBuilder<'_, TestStorage> = EnvironmentBuilder::default();
+
+        // Register only the opaque types used in the contract
+        let _ = env.register_opaque::<Address>("Address", true);
+
+        match abi_from_silex::<TestStorage>(&code, env) {
+            Ok(abi_json) => {
+                println!("Generated ABI:\n{}", abi_json);
+                assert!(abi_json.contains("entry"));
+            }
+            Err(err) => panic!("Failed to generate ABI: {:?}", err),
+        }
+    }
+}

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -7,6 +7,8 @@ use xelis_ast::*;
 use xelis_parser::mapper::GlobalMapper;
 use xelis_builder::Builder;
 
+#[warn(unused_extern_crates)]
+
 const ABI_VERSION: &str = "1.0.0";
 
 pub fn abi_from_silex<M>(code: &str, env: EnvironmentBuilder<'_, M>) -> anyhow::Result<String> {
@@ -227,7 +229,6 @@ pub fn abi_from_parse<M>(program: &Program, mapper: &GlobalMapper, environment: 
 mod tests {
     use super::*;
     use std::fs;
-    use std::marker::PhantomData;
 
     use xelis_builder::{EnvironmentBuilder};
     use xelis_types::{Opaque, traits::{

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -7,6 +7,8 @@ use xelis_ast::*;
 use xelis_parser::mapper::GlobalMapper;
 use xelis_builder::Builder;
 
+const ABI_VERSION = "1.0.0";
+
 pub fn abi_from_silex<M>(code: &str, env: EnvironmentBuilder<'_, M>) -> anyhow::Result<String> {
     let tokens = Lexer::new(code)
         .into_iter()
@@ -102,7 +104,12 @@ pub fn abi_from_parse<M>(program: &Program, mapper: &GlobalMapper, environment: 
         }
     }
 
-    Ok(serde_json::to_string_pretty(&abi_functions)?)
+    let abi_root = json!({
+        "version": ABI_VERSION,
+        "data": abi_functions
+    });
+
+    Ok(serde_json::to_string_pretty(&abi_root)?)
 }
 
 // TODO: re-add import support and switch to something like below

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -15,10 +15,10 @@ pub fn abi_from_silex<M>(code: &str, env: EnvironmentBuilder<'_, M>) -> anyhow::
     let parser = Parser::with(tokens.into_iter(), &env);
     let (program, mapper) = parser.parse().map_err(|err| anyhow::anyhow!("{:#}", err))?;
 
-    abi_from_parse(program, &mapper, &env)
+    abi_from_parse(&program, &mapper, &env)
 }
 
-pub fn abi_from_parse<M>(program: Program, mapper: &GlobalMapper, environment: &EnvironmentBuilder<M>) -> anyhow::Result<String> {
+pub fn abi_from_parse<M>(program: &Program, mapper: &GlobalMapper, environment: &EnvironmentBuilder<M>) -> anyhow::Result<String> {
     // Collect all the available entry functions
     let mut abi_functions: Vec<serde_json::Value> = Vec::new();
     for (i, func) in program.functions().iter().enumerate() {

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -230,7 +230,7 @@ mod tests {
     use std::marker::PhantomData;
 
     use xelis_builder::{EnvironmentBuilder};
-    use xelis_types::{Type, Opaque, OpaqueType, traits::{
+    use xelis_types::{Opaque, traits::{
       DynType, DynEq, DynHash, JSONHelper, Serializable
     }};
 
@@ -296,16 +296,6 @@ mod tests {
     // Dummy type definitions to register opaque types
     impl_dummy_opaque!(Address);
 
-    pub struct TestStorage {
-        _phantom: PhantomData<()>,
-    }
-
-    impl Default for TestStorage {
-        fn default() -> Self {
-            Self { _phantom: PhantomData }
-        }
-    }
-
     #[test]
     fn test_abi_from_example_slx() {
         let slx_path = "./silex/example.slx";
@@ -316,10 +306,10 @@ mod tests {
         let expected_abi = fs::read_to_string(abi_path)
             .expect("Failed to read example.abi.json");
 
-        let mut env: EnvironmentBuilder<'_, TestStorage> = EnvironmentBuilder::default();
+        let mut env: EnvironmentBuilder<'_, ()> = EnvironmentBuilder::default();
         let _ = env.register_opaque::<Address>("Address", true);
 
-        match abi_from_silex::<TestStorage>(&code, env) {
+        match abi_from_silex::<()>(&code, env) {
             Ok(generated_abi) => {
                 let generated_json: serde_json::Value = serde_json::from_str(&generated_abi).unwrap();
                 let expected_json: serde_json::Value = serde_json::from_str(&expected_abi).unwrap();

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,6 +1,6 @@
 mod context;
 mod error;
-mod mapper;
+pub mod mapper;
 
 use std::{
     borrow::Cow,


### PR DESCRIPTION
These helper functions allow ABI to be generated from a Silex input string, or from a parsed program. 

Other than the abi workspace crate, I had to expose the mapper mod publically with `pub mod mapper` instead of just `mod mapper` for access to the `GlobalMapper` type.