### PR TITLE
fix: unary IsNot precedence

### DIFF
--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -464,6 +464,30 @@ impl<'a> Lexer<'a> {
                         column_end: self.column
                     }
                 },
+                // Handle '!' specially - can be standalone '!' or '!='
+                // Consecutive '!' operators (like !!) are valid
+                '!' => {
+                    let column_start = self.column;
+                    
+                    // Only special case: '!=' 
+                    if self.peek()? == '=' {
+                        self.advance()?;
+                        TokenResult {
+                            token: Token::OperatorNotEquals,
+                            line: self.line,
+                            column_start,
+                            column_end: self.column
+                        }
+                    } else {
+                        // Everything else: just return '!' and let parser handle validity
+                        TokenResult {
+                            token: Token::IsNot,
+                            line: self.line,
+                            column_start,
+                            column_end: self.column
+                        }
+                    }
+                },
                 // it's only a comment, skip until its end
                 '/' if {
                     let v = self.peek()?;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -2047,15 +2047,30 @@ impl<'a, M> Parser<'a, M> {
                         _ => return Err(err!(self, ParserErrorKind::UnexpectedToken(Token::Dot)))
                     }
                 },
-                Token::IsNot => { // it's an operator, but not declared as
-                    let expr = self.read_expression(context)?;
+                Token::IsNot => {
+                    // Count consecutive IsNot tokens
+                    let mut not_count = 1;
+                    while self.peek_is(Token::IsNot) {
+                        self.advance()?;
+                        not_count += 1;
+                    }
+                    
+                    // Read the expression that follows all the ! operators
+                    let expr = self.read_expr(delimiter, on_type, false, false, Some(&Type::Bool), context)?;
                     let expr_type = self.get_type_from_expression(on_type, &expr, context)?;
                     if *expr_type != Type::Bool {
                         return Err(err!(self, ParserErrorKind::InvalidValueType(expr_type.into_owned(), Type::Bool)))
                     }
-
-                    Expression::IsNot(Box::new(expr))
-                },
+                    
+                    // Always wrap at least once for coercion
+                    // If odd count: single wrap
+                    // If even count: double wrap (!!x becomes IsNot(IsNot(x)))
+                    if not_count % 2 == 1 {
+                        Expression::IsNot(Box::new(expr))
+                    } else {
+                        Expression::IsNot(Box::new(Expression::IsNot(Box::new(expr))))
+                    }
+                }
                 Token::OperatorTernary => {
                     if queue.is_empty() {
                         return Err(err!(self, ParserErrorKind::InvalidTernaryNoPreviousExpression));

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -2064,11 +2064,11 @@ impl<'a, M> Parser<'a, M> {
                     
                     // Always wrap at least once for coercion
                     // If odd count: single wrap
-                    // If even count: double wrap (!!x becomes IsNot(IsNot(x)))
+                    // If even count: direct cast to bool, happens implicitly from expected_type arg in the read_expr call above
                     if not_count % 2 == 1 {
                         Expression::IsNot(Box::new(expr))
                     } else {
-                        Expression::IsNot(Box::new(Expression::IsNot(Box::new(expr))))
+                        expr
                     }
                 }
                 Token::OperatorTernary => {

--- a/vm/src/tests/full.rs
+++ b/vm/src/tests/full.rs
@@ -359,7 +359,7 @@ fn test_isnot_invalid_sequences() {
     assert!(try_parse_code_with("fn main() -> bool { return !*true; }", &env).is_err());
     assert!(try_parse_code_with("fn main() -> bool { return !/false; }", &env).is_err());
     assert!(try_parse_code_with("fn main() -> bool { return !%true; }", &env).is_err());
-    assert!(try_parse_code_with("fn main() -> bool { return false !!= false }", &env).is_err());
+    assert!(try_parse_code_with("fn main() -> bool { return false !!= false; }", &env).is_err());
 }
 
 #[test]

--- a/vm/src/tests/full.rs
+++ b/vm/src/tests/full.rs
@@ -2,7 +2,7 @@ use xelis_compiler::Compiler;
 use xelis_environment::{Environment, EnvironmentError};
 use xelis_builder::EnvironmentBuilder;
 use xelis_lexer::Lexer;
-use xelis_parser::Parser;
+use xelis_parser::{Parser, ParserError};
 use xelis_types::{traits::{JSONHelper, Serializable}, Primitive};
 use super::*;
 
@@ -20,6 +20,28 @@ fn prepare_module_with<'a>(code: &str, env: EnvironmentBuilder<'a, ()>) -> (Modu
     let module = Compiler::new(&program, &env).compile().unwrap();
 
     (module, env)
+}
+
+#[track_caller]
+fn parse_code(code: &str) {
+    parse_code_with(code, EnvironmentBuilder::default())
+}
+
+#[track_caller]
+fn parse_code_with<'a>(code: &str, env: EnvironmentBuilder<'a, ()>) {
+    let tokens: Vec<_> = Lexer::new(code).into_iter().collect::<Result<_, _>>().unwrap();
+    let (_, _) = Parser::with(tokens.into_iter(), &env).parse().unwrap();
+}
+
+#[track_caller]
+fn try_parse_code_with<'a>(code: &'a str, env: &'a EnvironmentBuilder<'a, ()>) -> Result<(), ParserError<'a>> {
+    let tokens: Vec<_> = Lexer::new(code)
+        .into_iter()
+        .collect::<Result<_, _>>().unwrap();
+    
+    Parser::with(tokens.into_iter(), &env)
+        .parse()
+        .map(|_| ())
 }
 
 #[track_caller]
@@ -125,6 +147,226 @@ fn test_ternary_negative() {
     "#;
 
     assert_eq!(run_code(code), Primitive::U64(30));
+}
+
+#[test]
+fn test_isnot_basic() {
+    test_code_expect_return("fn main() -> bool { return !false; }", Primitive::Boolean(true));
+    test_code_expect_return("fn main() -> bool { return !true; }", Primitive::Boolean(false));
+}
+
+#[test]
+fn test_isnot_precedence_with_and() {
+    test_code_expect_return(
+        "fn main() -> bool { let feeless: bool = false; return !feeless && false; }", 
+        Primitive::Boolean(false)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { let feeless: bool = true; return !feeless && false; }", 
+        Primitive::Boolean(false)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { let feeless: bool = false; return !feeless && true; }", 
+        Primitive::Boolean(true)
+    );
+}
+
+#[test]
+fn test_isnot_precedence_with_and_parentheses() {
+    test_code_expect_return(
+        "fn main() -> bool { let feeless: bool = false; return (!feeless) && false; }", 
+        Primitive::Boolean(false)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { let feeless: bool = false; return (!feeless) && true; }", 
+        Primitive::Boolean(true)
+    );
+}
+
+#[test]
+fn test_isnot_precedence_with_equals() {
+    test_code_expect_return(
+        "fn main() -> bool { return !true == false; }", 
+        Primitive::Boolean(true)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !false == true; }", 
+        Primitive::Boolean(true)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !true == true; }", 
+        Primitive::Boolean(false)
+    );
+}
+
+#[test]
+fn test_isnot_with_or() {
+    test_code_expect_return(
+        "fn main() -> bool { return !false || false; }", 
+        Primitive::Boolean(true)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !true || false; }", 
+        Primitive::Boolean(false)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !true || true; }", 
+        Primitive::Boolean(true)
+    );
+}
+
+#[test]
+fn test_isnot_grouped_expression() {
+    test_code_expect_return(
+        "fn main() -> bool { return !(true && false); }", 
+        Primitive::Boolean(true)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !(true && true); }", 
+        Primitive::Boolean(false)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !(false || false); }", 
+        Primitive::Boolean(true)
+    );
+}
+
+#[test]
+fn test_isnot_grouped_vs_precedence() {
+    test_code_expect_return(
+        "fn main() -> bool { return !(true || false); }", 
+        Primitive::Boolean(false)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !true || false; }", 
+        Primitive::Boolean(false)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !(false || true); }", 
+        Primitive::Boolean(false)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !false || true; }", 
+        Primitive::Boolean(true)
+    );
+}
+
+#[test]
+fn test_isnot_chain() {
+    test_code_expect_return(
+        "fn main() -> bool { let x: bool = true; return !!x; }", 
+        Primitive::Boolean(true)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { let x: bool = false; return !!x; }", 
+        Primitive::Boolean(false)
+    );
+}
+
+#[test]
+fn test_isnot_complex_precedence() {
+    test_code_expect_return(
+        "fn main() -> bool { return !false && true || false; }", 
+        Primitive::Boolean(true)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !true && false || true; }", 
+        Primitive::Boolean(true)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { return !true && true || false; }", 
+        Primitive::Boolean(false)
+    );
+}
+
+#[test]
+fn test_isnot_with_variable_expressions() {
+    test_code_expect_return(
+        "fn main() -> bool { let a: bool = true; let b: bool = false; let c: bool = !a == b; return c; }", 
+        Primitive::Boolean(true)
+    );
+    
+    test_code_expect_return(
+        "fn main() -> bool { let a: bool = false; let b: bool = false; let c: bool = !a == b; return c; }", 
+        Primitive::Boolean(false)
+    );
+}
+
+#[test]
+fn test_isnot_in_conditions() {
+    test_code_expect_return(
+        "entry main() { let x: bool = false; if !x { return 1; } return 0; }", 
+        Primitive::U64(1)
+    );
+    
+    test_code_expect_return(
+        "entry main() { let x: bool = true; if !x { return 1; } return 0; }", 
+        Primitive::U64(0)
+    );
+    
+    test_code_expect_return(
+        "entry main() { let x: bool = false; if !x && false { return 0; } return 1; }", 
+        Primitive::U64(1)
+    );
+
+    test_code_expect_return(
+        "entry main() { let x: bool = false; if !(x && false) { return 0; } return 1; }", 
+        Primitive::U64(0)
+    );
+}
+
+#[test]
+fn test_isnot_longer_chains() {
+    test_code_expect_return("fn main() -> bool { return !!!true; }", Primitive::Boolean(false));
+    test_code_expect_return("fn main() -> bool { return !!!!true; }", Primitive::Boolean(true));
+    test_code_expect_return("fn main() -> bool { return !!!!!false; }", Primitive::Boolean(true));
+    test_code_expect_return("fn main() -> bool { return !!!!!!false; }", Primitive::Boolean(false));
+}
+
+#[test]
+fn test_isnot_chains_with_variables() {
+    test_code_expect_return("fn main() -> bool { let x: bool = false; return !!!x; }", Primitive::Boolean(true));
+    test_code_expect_return("fn main() -> bool { let x: bool = true; return !!!!x; }", Primitive::Boolean(true));
+}
+
+#[test]
+fn test_isnot_chains_with_expressions() {
+    test_code_expect_return("fn main() -> bool { return !!(true && false); }", Primitive::Boolean(false));
+    test_code_expect_return("fn main() -> bool { return !!!(true || false); }", Primitive::Boolean(false));
+    test_code_expect_return("fn main() -> bool { return !!!!(false || false); }", Primitive::Boolean(false));
+}
+
+#[test]
+fn test_isnot_invalid_sequences() {
+    let env = EnvironmentBuilder::<()>::default();
+    assert!(try_parse_code_with("fn main() -> bool { return !+true; }", &env).is_err());
+    assert!(try_parse_code_with("fn main() -> bool { return !-false; }", &env).is_err());
+    assert!(try_parse_code_with("fn main() -> bool { return !*true; }", &env).is_err());
+    assert!(try_parse_code_with("fn main() -> bool { return !/false; }", &env).is_err());
+    assert!(try_parse_code_with("fn main() -> bool { return !%true; }", &env).is_err());
+    assert!(try_parse_code_with("fn main() -> bool { return false !!= false }", &env).is_err());
+}
+
+#[test]
+fn test_isnot_valid_edge_cases() {
+    test_code_expect_return("fn main() -> bool { return !(true); }", Primitive::Boolean(false));
+    test_code_expect_return("fn main() -> bool { let x: bool[] = [!true, !false]; return x[0]; }", Primitive::Boolean(false));
+    test_code_expect_return("fn main() -> bool { return !true != false; }", Primitive::Boolean(false));
 }
 
 #[test]


### PR DESCRIPTION
Fixes bug found by dalkson regarding expressions like `!false && false` evaluating to `true` due to the parser interpreting it as `!(fals && false)`, while also enabling valid (but optimized, max 2 nesting levels) chained IsNot, like `!!!false == true` being `true`.

Robust test cases have been added alongside the correction in parsing logic.